### PR TITLE
fix(*): made dynamic, kept a reference to the providers.

### DIFF
--- a/ZappPushPluginsSDK.podspec
+++ b/ZappPushPluginsSDK.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "git@github.com:applicaster/ZappPushPluginsSDK-iOS.git", :tag => s.version.to_s }
   s.platform         = :ios, '9.0'
   s.requires_arc = true
-  s.static_framework = true
+  s.static_framework = false
 
   s.source_files  = 'ZappPushPluginsSDK/**/*.{swift}'
   s.xcconfig =  { 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',

--- a/ZappPushPluginsSDK/ZPPushNotificationManager.swift
+++ b/ZappPushPluginsSDK/ZPPushNotificationManager.swift
@@ -10,6 +10,8 @@ import ZappPlugins
 
 @objc public class ZPPushNotificationManager: NSObject {
     @objc public static let sharedInstance = ZPPushNotificationManager()
+	
+	var providers: [ZPPushProviderProtocol] = []
     
     private override init() {
         //This prevents others from using the default '()' initializer for this class.
@@ -19,16 +21,18 @@ import ZappPlugins
      private method - Get providers types from Zapp
      */
     @objc public func getProviders() -> [ZPPushProviderProtocol] {
-        var providers = [ZPPushProviderProtocol]()
-        let pluginModels = ZPPluginManager.pluginModels()?.filter { $0.pluginType == .Push }
-        if let pluginModels = pluginModels  {
-            for pluginModel in pluginModels {
-                if let classType = ZPPluginManager.adapterClass(pluginModel) as? ZPPushProviderProtocol.Type {
-                    let provider = classType.init(configurationJSON: pluginModel.configurationJSON)
-                    providers.append(provider)
-                }
-            }
-        }
+		if providers.count == 0 {
+			//var providers = [ZPPushProviderProtocol]()
+			let pluginModels = ZPPluginManager.pluginModels()?.filter { $0.pluginType == .Push }
+			if let pluginModels = pluginModels  {
+				for pluginModel in pluginModels {
+					if let classType = ZPPluginManager.adapterClass(pluginModel) as? ZPPushProviderProtocol.Type {
+						let provider = classType.init(configurationJSON: pluginModel.configurationJSON)
+						providers.append(provider)
+					}
+				}
+			}
+		}
         return providers
     }
 }


### PR DESCRIPTION
## Description:

To allow the delegates setup by the `ZPPushProviders` to remain in place I've kept a reference to the providers when they are first initialised.
However as a `static framework` the `ZPPushNotificationManager` would be instantiated multiple times, so it has been changed to a `dynamic framework` to maintain it's singleton functionality.

## Known Issues:

### Checklist for this pull request
- [x] PR is scoped to one task
- [ ] Tests included

- One of:
  - [x] The PR is not making any UI change
  - [ ] The PR is making a UI change
    - [ ] Screenshots included

 ## QA:
  - Required test cases:
  - Which apps this change/fix should be tested on:

Thank you!